### PR TITLE
Improve task list layout

### DIFF
--- a/main.py
+++ b/main.py
@@ -28,9 +28,9 @@ async def main(page: ft.Page):
     task_name = ft.TextField(label="Task Name", expand=True)
     task_duration = ft.TextField(label="Duration (min)", width=150)
     status = ft.Text()
-    tasks_column = ft.Column(expand=True, spacing=2)
+    tasks_column = ft.ListView(expand=True, spacing=2)
 
-    timer_label = ft.Text(size=24, weight="bold")
+    timer_label = ft.Text(size=36, weight="bold")
     main_view = ft.Column(
         [
             task_name,
@@ -46,7 +46,6 @@ async def main(page: ft.Page):
             ),
             ft.Container(
                 tasks_column,
-                height=250,
                 bgcolor=ft.Colors.SURFACE_CONTAINER_HIGHEST,
                 expand=True,
                 padding=5,


### PR DESCRIPTION
## Summary
- make the timer text larger
- let the task list fill remaining page height responsively

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_68458b1e7264832fb56115a47a5e872b