### PR TITLE
Fix scroll for empty task list

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,6 +48,7 @@ async def main(page: ft.Page):
                 tasks_column,
                 bgcolor=ft.Colors.SURFACE_CONTAINER_HIGHEST,
                 expand=True,
+                scroll=ft.ScrollMode.ALWAYS,
                 padding=5,
                 border_radius=5,
                 clip_behavior=ft.ClipBehavior.HARD_EDGE,


### PR DESCRIPTION
## Summary
- keep the task list container scrollable so it still fills the space when empty

## Testing
- `ruff check .`

------
https://chatgpt.com/codex/tasks/task_e_68458cd6447c832f9c4493bf65d7b09a