### PR TITLE
Fix Flet incompatibility

### DIFF
--- a/main.py
+++ b/main.py
@@ -48,7 +48,6 @@ async def main(page: ft.Page):
                 tasks_column,
                 bgcolor=ft.Colors.SURFACE_CONTAINER_HIGHEST,
                 expand=True,
-                scroll=ft.ScrollMode.ALWAYS,
                 padding=5,
                 border_radius=5,
                 clip_behavior=ft.ClipBehavior.HARD_EDGE,


### PR DESCRIPTION
## Summary
- remove unsupported `scroll` argument from `ft.Container`

## Testing
- `python main.py` *(fails to show UI in container but produced no TypeError)*

------
https://chatgpt.com/codex/tasks/task_e_68458e0e2c0c832f85950a07801ec4fa